### PR TITLE
fix: correct account data parsing from API response

### DIFF
--- a/lib/tastytrade/models/account.rb
+++ b/lib/tastytrade/models/account.rb
@@ -20,7 +20,7 @@ module Tastytrade
         def get_all(session, include_closed: false)
           params = include_closed ? { "include-closed" => true } : {}
           response = session.get("/customers/me/accounts/", params)
-          response["data"]["items"].map { |item| new(item) }
+          response["data"]["items"].map { |item| new(item["account"]) }
         end
 
         # Get a specific account by account number

--- a/lib/tastytrade/models/base.rb
+++ b/lib/tastytrade/models/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module Tastytrade
   module Models
     # Base class for all Tastytrade data models

--- a/spec/tastytrade/models/account_spec.rb
+++ b/spec/tastytrade/models/account_spec.rb
@@ -57,8 +57,14 @@ RSpec.describe Tastytrade::Models::Account do
       {
         "data" => {
           "items" => [
-            account_data,
-            account_data.merge("account-number" => "789012")
+            {
+              "account" => account_data,
+              "authority-level" => "owner"
+            },
+            {
+              "account" => account_data.merge("account-number" => "789012"),
+              "authority-level" => "owner"
+            }
           ]
         }
       }


### PR DESCRIPTION
## Summary
Fixed account data parsing issue that was causing empty account numbers in CLI display.

## Problem
The accounts endpoint returns data with the account information nested inside an "account" key:
```json
{
  "data": {
    "items": [
      {
        "account": { ... actual account data ... },
        "authority-level": "owner"
      }
    ]
  }
}
```

Our Account model was expecting the data at the top level, resulting in nil values for all account attributes.

## Solution
1. Updated `Account.get_all` to extract data from the nested "account" key
2. Added missing `require "time"` to Base model for proper datetime parsing

## Testing
- Tested with sandbox account credentials
- Verified `tastytrade accounts` now displays account information correctly
- Confirmed account selection works properly

## Before
```
┌───┬──────────┬──────────────┬────────┬────────┐
│   │ Account  │ Nickname     │ Type   │ Status │
├───┼──────────┼──────────────┼────────┼────────┤
│   │          │ -            │ Unknown│ Active │
└───┴──────────┴──────────────┴────────┴────────┘
```

## After
```
┌───┬──────────┬──────────────┬────────────┬────────┐
│   │ Account  │ Nickname     │ Type       │ Status │
├───┼──────────┼──────────────┼────────────┼────────┤
│   │ 5WZ31145 │ Individual   │ Individual │ Active │
└───┴──────────┴──────────────┴────────────┴────────┘
```