### PR TITLE
chore: remove MFA requirement and update release process

### DIFF
--- a/.claude/commands/release-pr.md
+++ b/.claude/commands/release-pr.md
@@ -85,9 +85,9 @@ Create a release PR following Ruby gem best practices.
    ### Post-Merge Steps
    After merging this PR:
    1. \`git checkout main && git pull\`
-   2. \`git tag v<VERSION>\`
-   3. \`git push --tags\`
-   4. \`bundle exec rake release\`"
+   2. \`bundle exec rake release\`
+   
+   Note: The rake release command will automatically create and push the git tag v<VERSION>"
    ```
 
 ## Important Notes
@@ -96,7 +96,8 @@ Create a release PR following Ruby gem best practices.
 - Ensure all tests pass before creating the PR
 - Run RuboCop to ensure code quality
 - The version in the PR title and body should NOT include the 'v' prefix (e.g., "0.2.0" not "v0.2.0")
-- The git tag SHOULD include the 'v' prefix (e.g., "v0.2.0")
+- The rake release command will automatically create the git tag with 'v' prefix (e.g., "v0.2.0")
+- You need a RubyGems.org account to run rake release
 
 ## Example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account.get_positions now returns array of CurrentPosition objects instead of raw hashes
 - CLI menus now use consistent vim-style navigation with extracted helper method
 - Updated release-pr Claude Code command to include ROADMAP.md updates in release process
+- Removed MFA requirement for RubyGems.org publishing
+- Updated release-pr command to reflect that rake release auto-creates git tags
 
 ### Fixed
 - Account data parsing from API response (#25)

--- a/tastytrade.gemspec
+++ b/tastytrade.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/ryanhamamura/tastytrade/blob/main/CHANGELOG.md"
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/tastytrade"
   spec.metadata["bug_tracker_uri"] = "https://github.com/ryanhamamura/tastytrade/issues"
-  spec.metadata["rubygems_mfa_required"] = "true"
+  spec.metadata["rubygems_mfa_required"] = "false"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Summary
This PR removes the MFA requirement for RubyGems.org publishing and updates the release process documentation.

## Changes
- Set `rubygems_mfa_required` to `false` in gemspec
- Updated release-pr command to remove manual git tag creation steps
- Added note that `rake release` automatically creates and pushes the git tag
- Updated CHANGELOG.md to document these changes

## Rationale
- Simplifies the gem publishing process for maintainers
- Removes redundant git tag creation steps since `rake release` handles this automatically
- Makes it easier to reserve the gem name on RubyGems.org

## Testing
The changes will take effect when we run `rake release` to publish the gem.