### PR TITLE
feat: add CLI support for order time-in-force (DAY/GTC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Order time-in-force CLI support (#15)
+  - Added --time-in-force option to `order place` command
+  - Support for DAY and GTC (Good Till Cancelled) order durations
+  - Accepts shorthand aliases: "d" for DAY, "g" or "good_till_cancelled" for GTC
+  - Defaults to DAY order when not specified (backward compatible)
+  - Display time-in-force in order summaries and order history tables
+  - Added TIF column to order list and history displays
+  - Complete test coverage for time-in-force parameter handling
+  - Note: Core Order class already had full DAY/GTC support
 - Comprehensive order validation framework (#14)
   - OrderValidator class with multi-layer validation checks
   - Symbol validation via Instruments API

--- a/spec/tastytrade/cli_orders_spec.rb
+++ b/spec/tastytrade/cli_orders_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tastytrade/cli"
+
+RSpec.describe "CLI Order Placement" do
+  let(:cli) { Tastytrade::CLI::Orders.new }
+  let(:session) { instance_double(Tastytrade::Session) }
+  let(:account) { instance_double(Tastytrade::Models::Account, account_number: "5WT00000") }
+
+  before do
+    allow(cli).to receive(:current_session).and_return(session)
+    allow(cli).to receive(:current_account).and_return(account)
+    allow(cli).to receive(:require_authentication!)
+    allow(cli).to receive(:puts)
+    allow(cli).to receive(:info)
+    allow(cli).to receive(:success)
+    allow(cli).to receive(:error)
+    allow(cli).to receive(:prompt).and_return(instance_double(TTY::Prompt, yes?: true))
+    allow(cli).to receive(:format_currency) { |val| "$#{val}" }
+  end
+
+  describe "time_in_force parameter" do
+    let(:order_response) do
+      instance_double(
+        Tastytrade::Models::OrderResponse,
+        order_id: "12345",
+        buying_power_effect: BigDecimal("-150.00"),
+        warnings: [],
+        errors: [],
+        status: "Routed"
+      )
+    end
+
+    before do
+      allow(account).to receive(:place_order).and_return(order_response)
+      allow(cli).to receive(:exit)
+    end
+
+    context "when placing a DAY order" do
+      it "creates an order with DAY time_in_force (default)" do
+        expect(Tastytrade::Order).to receive(:new).with(
+          type: Tastytrade::OrderType::LIMIT,
+          time_in_force: Tastytrade::OrderTimeInForce::DAY,
+          legs: anything,
+          price: BigDecimal("150.00")
+        ).and_call_original
+
+        allow(cli).to receive(:options).and_return({
+                                                     symbol: "AAPL",
+                                                     action: "buy_to_open",
+                                                     quantity: 100,
+                                                     type: "limit",
+                                                     price: 150.00,
+                                                     time_in_force: "day",
+                                                     skip_confirmation: true
+                                                   })
+
+        expect { cli.place }.not_to raise_error
+      end
+
+      it "accepts 'd' as shorthand for day" do
+        expect(Tastytrade::Order).to receive(:new).with(
+          type: Tastytrade::OrderType::LIMIT,
+          time_in_force: Tastytrade::OrderTimeInForce::DAY,
+          legs: anything,
+          price: BigDecimal("150.00")
+        ).and_call_original
+
+        allow(cli).to receive(:options).and_return({
+                                                     symbol: "AAPL",
+                                                     action: "buy_to_open",
+                                                     quantity: 100,
+                                                     type: "limit",
+                                                     price: 150.00,
+                                                     time_in_force: "d",
+                                                     skip_confirmation: true
+                                                   })
+
+        expect { cli.place }.not_to raise_error
+      end
+    end
+
+    context "when placing a GTC order" do
+      it "creates an order with GTC time_in_force" do
+        expect(Tastytrade::Order).to receive(:new).with(
+          type: Tastytrade::OrderType::LIMIT,
+          time_in_force: Tastytrade::OrderTimeInForce::GTC,
+          legs: anything,
+          price: BigDecimal("150.00")
+        ).and_call_original
+
+        allow(cli).to receive(:options).and_return({
+                                                     symbol: "AAPL",
+                                                     action: "buy_to_open",
+                                                     quantity: 100,
+                                                     type: "limit",
+                                                     price: 150.00,
+                                                     time_in_force: "gtc",
+                                                     skip_confirmation: true
+                                                   })
+
+        expect { cli.place }.not_to raise_error
+      end
+
+      it "accepts 'g' as shorthand for GTC" do
+        expect(Tastytrade::Order).to receive(:new).with(
+          type: Tastytrade::OrderType::LIMIT,
+          time_in_force: Tastytrade::OrderTimeInForce::GTC,
+          legs: anything,
+          price: BigDecimal("150.00")
+        ).and_call_original
+
+        allow(cli).to receive(:options).and_return({
+                                                     symbol: "AAPL",
+                                                     action: "buy_to_open",
+                                                     quantity: 100,
+                                                     type: "limit",
+                                                     price: 150.00,
+                                                     time_in_force: "g",
+                                                     skip_confirmation: true
+                                                   })
+
+        expect { cli.place }.not_to raise_error
+      end
+
+      it "accepts 'good_till_cancelled' as GTC alias" do
+        expect(Tastytrade::Order).to receive(:new).with(
+          type: Tastytrade::OrderType::LIMIT,
+          time_in_force: Tastytrade::OrderTimeInForce::GTC,
+          legs: anything,
+          price: BigDecimal("150.00")
+        ).and_call_original
+
+        allow(cli).to receive(:options).and_return({
+                                                     symbol: "AAPL",
+                                                     action: "buy_to_open",
+                                                     quantity: 100,
+                                                     type: "limit",
+                                                     price: 150.00,
+                                                     time_in_force: "good_till_cancelled",
+                                                     skip_confirmation: true
+                                                   })
+
+        expect { cli.place }.not_to raise_error
+      end
+    end
+
+    context "with invalid time_in_force" do
+      it "exits with error for invalid value" do
+        expect(cli).to receive(:error).with("Invalid time in force. Must be: day or gtc")
+        expect(cli).to receive(:exit).with(1).and_raise(SystemExit)
+
+        allow(cli).to receive(:options).and_return({
+                                                     symbol: "AAPL",
+                                                     action: "buy_to_open",
+                                                     quantity: 100,
+                                                     type: "limit",
+                                                     price: 150.00,
+                                                     time_in_force: "invalid",
+                                                     skip_confirmation: true
+                                                   })
+
+        expect { cli.place }.to raise_error(SystemExit)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Added `--time-in-force` option to CLI `order place` command
- Support for DAY and GTC (Good Till Cancelled) order durations
- User-friendly aliases: "d" for DAY, "g" or "good_till_cancelled" for GTC

## Implementation Details
The core Order class already had full support for DAY/GTC time-in-force values. This PR adds the missing CLI interface to expose this functionality to users.

### Changes:
- **CLI Option**: Added `--time-in-force` parameter to order placement
- **Default Behavior**: Defaults to DAY for backward compatibility
- **Display Enhancement**: Added TIF column to order lists and displays time-in-force in order details
- **Input Validation**: Clear error messages for invalid time-in-force values
- **Test Coverage**: Comprehensive tests for all time-in-force scenarios

## Test Plan
- [x] Unit tests for CLI time-in-force parameter handling
- [x] Tests for DAY order placement
- [x] Tests for GTC order placement
- [x] Tests for shorthand aliases
- [x] Tests for invalid input handling
- [x] All existing tests passing (563 examples, 0 failures)

Closes #15