### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Nothing yet
 
+## [0.3.1] - 2025-08-08
+
+### Removed
+- VCR documentation files (vcr_implementation_plan.md, vcr_implementation_research.md) that were inadvertently included in v0.3.0
+- VCR gem dependency from development dependencies
+- VCR configuration and setup code from spec_helper.rb
+- VCR-related test tags from spec files
+
+### Fixed
+- Cleaned up test suite to remove unused VCR references
+
 ## [0.3.0] - 2025-08-08
 
 ### Added

--- a/lib/tastytrade/version.rb
+++ b/lib/tastytrade/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tastytrade
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
## Release v0.3.1

This PR prepares the patch release of version 0.3.1.

### Changes
- Bumped version to 0.3.1
- Updated CHANGELOG.md with release date and changes

### What's Fixed
- Removed VCR documentation files that were inadvertently included in v0.3.0
- Removed VCR gem dependency and all VCR-related code from the test suite
- Cleaned up test configuration to remove unused VCR references

### Release Checklist
- [x] Version number is correct
- [x] CHANGELOG.md is updated with all changes
- [x] All tests pass
- [x] RuboCop reports no offenses

### Post-Merge Steps
After merging this PR:
1. `git checkout main && git pull`
2. `bundle exec rake release` (This will create git tag, build gem, and push to RubyGems.org)
3. Create a GitHub Release:
   ```bash
   gh release create v0.3.1 \\
     --title "v0.3.1" \\
     --generate-notes \\
     --draft
   ```
4. Edit the draft release to add a summary section at the top with key highlights
5. Publish the release:
   ```bash
   gh release edit v0.3.1 --draft=false
   ```

Note: The `rake release` command will:
- Create and push the git tag v0.3.1
- Build the gem (tastytrade-0.3.1.gem)
- Push the gem to RubyGems.org
- Require your RubyGems.org credentials for the push