### PR TITLE
feat: add interactive orders menu system with Thor integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Nothing yet
+- Interactive orders menu system (#49)
+  - New hierarchical orders submenu replacing single order placement
+  - Three-tier place order system (Quick/Standard/Advanced modes)
+  - Interactive wrappers for all Thor order subcommands:
+    - List orders with filters (status, symbol) and auto-refresh capability
+    - Order history with date range, status, and symbol filters
+    - Get order details by ID
+    - Cancel orders with visual selection
+    - Replace/modify existing orders
+  - Enhanced error handling with human-readable messages
+  - Context-aware confirmations (SANDBOX vs PRODUCTION warnings)
+  - Session management via instance variable injection to Thor commands
+  - Vim-style navigation throughout all menus
+  - Status colorization for better visual feedback
 
 ### Changed
-- Nothing yet
+- Main menu "Orders" option now opens comprehensive orders management submenu
+- Order operations return to orders submenu instead of main menu
 
 ### Deprecated
 - Nothing yet


### PR DESCRIPTION
## Summary
- Implements comprehensive interactive orders menu system
- Integrates all Thor order subcommands into interactive mode
- Provides three-tier order placement system for different user needs

## Changes
### New Interactive Orders Menu
- Replaced single `interactive_order` method with full `interactive_orders_menu`
- Hierarchical menu structure with all order operations
- Returns to orders submenu after operations (not main menu)

### Three-Tier Place Order System
- **Quick Order**: Basic market/limit orders for fast execution
- **Standard Order**: Common order types with all actions and time-in-force options
- **Advanced Order**: Full feature set (delegates to existing method, ready for future enhancements)

### Thor Integration
- Instance variable injection for session and account management
- Wrapper methods for all Thor subcommands:
  - `list` - View live orders with filters and auto-refresh
  - `history` - View past orders with date/status/symbol filters
  - `get` - View specific order details
  - `cancel` - Cancel orders with visual selection
  - `replace` - Modify existing orders
  - `place` - Create new orders with three complexity levels

### Enhanced User Experience
- Human-readable error messages with "Press any key to continue" prompts
- Context-aware confirmations (SANDBOX vs PRODUCTION warnings)
- Auto-refresh capability for live orders (5-second intervals)
- Status colorization for better visual feedback
- Vim-style navigation throughout all menus
- SystemExit catching to handle Thor's exit calls gracefully

## Test Plan
- [x] All existing tests pass
- [x] RuboCop linting passes with no offenses
- [x] Manual testing of all menu options
- [x] Backward compatibility maintained

Closes #49